### PR TITLE
feat: add dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# nothing should be needed as we import only dist as well as nginx.conf, and do not use wildcards.
+.env
+sample.env

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ on:
       - '**'  # Listen to all branches
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}  # Does not distinguish PRs, for this workflow won't run on PR branches
   cancel-in-progress: true
 
 jobs:
@@ -41,12 +41,13 @@ jobs:
           CONTENTFUL_DELIVERY_TOKEN: ${{ secrets.CONTENTFUL_DELIVERY_TOKEN }}
           CONTENTFUL_ENVIRONMENT:    ${{ vars.CONTENTFUL_ENVIRONMENT }}
 
+      # Astro will produce a build in `dist/`
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: website-build-static-files
           path: ./dist/
-          retention-days: 45
+          retention-days: 45  # Default value is 90, and cannot be higher than that. Because of this we have the cron job above to prevent the latest artifact from being deleted without being replaced. Since we do that monthly anyway, we remove it earlier for we use less storage that way.
 
   deploy:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/development'
@@ -56,7 +57,7 @@ jobs:
     environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'development' }}
 
     steps:
-      - name: Trigger deploy on server
+      - name: Trigger deploy on server  # Triggers a webhook on our server, handled by Aas (svsticky/aas)
         uses: distributhor/workflow-webhook@v3
         env:
           webhook_url:    ${{ vars.AAS_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,3 +67,34 @@ jobs:
           webhook_url:    ${{ vars.AAS_URL }}
           webhook_secret: ${{ secrets.AAS_PRE_SHARED_KEY }}
 
+  dockerize:
+    name: Package Docker image as artifact
+    needs: build
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'development' }}
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download Astro build artifact (dist/)
+        uses: actions/download-artifact@v4
+        with:
+          name: website-build-static-files
+          path: dist/
+      
+      - name: Build Docker image
+        run: |
+          docker build -t astro-site:${{ github.event.commit_id }} .
+
+      # as we do not have a proper docker registry yet; just save it as an artifact. TODO: make this push to our self-hosted docker registry.
+      - name: Save Docker image as .tar
+        run: |
+          docker save astro-site | gzip > astro-site.tar.gz
+
+      - name: Upload Docker image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: astro-site-docker-image
+          path: astro-site.tar.gz
+          retention-days: 30

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ on:
       - '**'  # Listen to all branches
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}  # Does not distinguish PRs, for this workflow won't run on PR branches
+  group: ${{ github.workflow }}-${{ github.ref }} # Does not distinguish PRs, for this workflow won't run on PR branches
   cancel-in-progress: true
 
 jobs:
@@ -47,7 +47,7 @@ jobs:
         with:
           name: website-build-static-files
           path: ./dist/
-          retention-days: 45  # Default value is 90, and cannot be higher than that. Because of this we have the cron job above to prevent the latest artifact from being deleted without being replaced. Since we do that monthly anyway, we remove it earlier for we use less storage that way.
+          retention-days: 45 # Default value is 90, and cannot be higher than that. Because of this we have the cron job above to prevent the latest artifact from being deleted without being replaced. Since we do that monthly anyway, we remove it earlier for we use less storage that way.
 
   deploy:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/development'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,7 +85,7 @@ jobs:
       
       - name: Build Docker image
         run: |
-          docker build -t astro-site:${{ github.event.commit_id }} .
+          docker build -t astro-site:${{ github.sha }} .
 
       # as we do not have a proper docker registry yet; just save it as an artifact. TODO: make this push to our self-hosted docker registry.
       - name: Save Docker image as .tar

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,13 +9,10 @@ on:
 
   push:
     branches:
-      - main
-      - development
+      - '**'  # Listen to all branches
 
-# Ensure only the latest job runs on the same branch, to safe the environment.
-# Also prevents slower jobs from replacing the latest artifact, when concurrently running two jobs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }} # Does not distinguish PRs, for this workflow won't run on PR branches
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -44,30 +41,29 @@ jobs:
           CONTENTFUL_DELIVERY_TOKEN: ${{ secrets.CONTENTFUL_DELIVERY_TOKEN }}
           CONTENTFUL_ENVIRONMENT:    ${{ vars.CONTENTFUL_ENVIRONMENT }}
 
-      # Astro will produce a build in `dist/`
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: website-build-static-files
           path: ./dist/
-          retention-days: 45 # Default value is 90, and cannot be higher than that. Because of this we have the cron job above to prevent the latest artifact from being deleted without being replaced. Since we do that monthly anyway, we remove it earlier for we use less storage that way.
+          retention-days: 45
 
   deploy:
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/development'
     name: Notify server of new artifact
-          # The server will pull the artifact and deploy it. We simply have to whisper in its ear.
     needs: build
     runs-on: ubuntu-latest
     environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'development' }}
 
     steps:
       - name: Trigger deploy on server
-        # Triggers a webhook on our server, handled by Aas (svsticky/aas)
         uses: distributhor/workflow-webhook@v3
         env:
           webhook_url:    ${{ vars.AAS_URL }}
           webhook_secret: ${{ secrets.AAS_PRE_SHARED_KEY }}
 
   dockerize:
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/development'
     name: Package Docker image as artifact
     needs: build
     runs-on: ubuntu-latest
@@ -85,7 +81,7 @@ jobs:
       
       - name: Build Docker image
         run: |
-          docker build -t astro-site:${{ github.sha }} .
+          docker build -t astro-site:${{ github.sha }} . --build-arg BUILD_NUMBER=${{ github.run_id }}
 
       # as we do not have a proper docker registry yet; just save it as an artifact. TODO: make this push to our self-hosted docker registry.
       - name: Save Docker image as .tar

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,12 @@ COPY dist/ /usr/share/nginx/html/
 # Copy secure nginx config, which is owned by root
 COPY nginx.conf /etc/nginx/nginx.conf
 
+RUN mkdir -p /var/cache/nginx/client_temp /run && \
+    chown -R astro:astro /var/cache/nginx /run
+
 # become astro user so you are rootless
 USER astro
 
-EXPOSE 80
+EXPOSE 8080
 
 # Default command remains

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM nginx:1.25-alpine
+
+# Create non-root user and group
+RUN addgroup -S astro && adduser -S astro -G astro
+
+# Remove default files
+RUN rm -rf /usr/share/nginx/html/*
+
+# Copy static files
+COPY dist/ /usr/share/nginx/html/
+
+# Copy secure nginx config, which is owned by root
+COPY nginx.conf /etc/nginx/nginx.conf
+
+# become astro user so you are rootless
+RUN chown -R astro:astro /usr/share/nginx/html
+
+EXPOSE 80
+
+# Default command remains

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY dist/ /usr/share/nginx/html/
 COPY nginx.conf /etc/nginx/nginx.conf
 
 # become astro user so you are rootless
-RUN chown -R astro:astro /usr/share/nginx/html
+USER astro
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM nginx:1.28-alpine-slim
 
+ARG BUILD_NUMBER=notset
+
 # Create non-root user and group
 RUN addgroup -S astro && adduser -S astro -G astro
 
@@ -8,6 +10,7 @@ RUN rm -rf /usr/share/nginx/html/*
 
 # Copy static files
 COPY dist/ /usr/share/nginx/html/
+RUN echo ${BUILD_NUMBER} > /usr/share/nginx/html/version.txt
 
 # Copy secure nginx config, which is owned by root
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.25-alpine
+FROM nginx:1.28-alpine-slim
 
 # Create non-root user and group
 RUN addgroup -S astro && adduser -S astro -G astro

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,4 +1,4 @@
-user astro;
+pid /tmp/nginx.pid;
 worker_processes auto;
 
 events {
@@ -16,12 +16,20 @@ http {
     keepalive_timeout  65;
 
     server {
-        listen       80;
+        listen       8080;
         server_name  localhost;
 
         location / {
             root   /usr/share/nginx/html;
             index  index.html index.htm;
+            try_files $uri $uri/ =404;
+        }
+
+        # route to 404
+        error_page 404 /404.html;
+        location = /404.html {
+            root /usr/share/nginx/html;
+            internal;
         }
 
         # Disable directory listing

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,35 @@
+user astro;
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    access_log  /dev/stdout;
+    error_log   /dev/stderr warn;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    server {
+        listen       80;
+        server_name  localhost;
+
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+
+        # Disable directory listing
+        autoindex off;
+
+        # Add basic security headers
+        add_header X-Content-Type-Options nosniff;
+        add_header X-Frame-Options DENY;
+        add_header X-XSS-Protection "1; mode=block";
+    }
+}


### PR DESCRIPTION
added dockerfile (which is rootles, and follows a couple of other OWASP docker standard as well), as well as add it in the pipeline. As of now it generates a .tar.gz as an artifact, I will state below how to test

In the future, we could upload this image to our own container registry, and then pull from there.

## How to test
1. Run pipeline
2. download an artifact
3.  unzip the artifact (.zip becomes .tar.gz)
4. run `docker load < astro-site.tar.gz`
5. the output will give a docker image you have now saved locally. To run this image, run `docker run -p 81:8080 -it [name:tag]` sh. This will give you an interactive sh shell in the image (so you can tinker with rights), as well as host the site at localhost:81 